### PR TITLE
Fix tests and simplify library description

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.18.x, 1.19.x, 1.20.x]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - run: make

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/urfave/cli-altsrc/v3.svg)](https://pkg.go.dev/github.com/urfave/cli-altsrc/v3)
 [![Go Report Card](https://goreportcard.com/badge/github.com/urfave/cli-altsrc/v3)](https://goreportcard.com/report/github.com/urfave/cli-altsrc/v3)
 
-[`urfave/cli-altsrc/v3`](https://pkg.go.dev/github.com/urfave/cli-altsrc/v3) is an extended value source integration library for [`urfave/cli/v3`] with support for JSON,
-YAML, and TOML. The primary reason for this to be a separate library is that third-party libraries are used for these
-features which are otherwise not used throughout [`urfave/cli/v3`].
+[`urfave/cli-altsrc/v3`](https://pkg.go.dev/github.com/urfave/cli-altsrc/v3) is an extension for [`urfave/cli/v3`] to read
+flag values from JSON, YAML, and TOML. The extension keeps third-party libraries for these features away from [`urfave/cli/v3`].
 
 [`urfave/cli/v3`]: https://github.com/urfave/cli
 


### PR DESCRIPTION
Fixes this test failure by using Go version from `go.mod`.

```sh
$ go vet -v ./...
go: errors parsing go.mod:
/home/runner/work/cli-altsrc/cli-altsrc/go.mod:3: invalid go version '1.23.2': must match format 1.23
make: *** [Makefile:6: vet] Error 1
```

But doesn't fix this DNS lookup error that only occurs on GitHub.

```sh
=== RUN   TestReadURI/Invalid_http_URL
    uri_source_cache_test.go:55: 
        	Error Trace:	/home/runner/work/cli-altsrc/cli-altsrc/uri_source_cache_test.go:55
        	Error:      	Error "Get \"http://foo\": dial tcp: lookup foo on 127.0.0.53:53: server misbehaving" does not contain "no such host"
        	Test:       	TestReadURI/Invalid_http_URL
``

The example below still lacks proper imports to be standalone.