### PR TITLE
Support root level nested value lookups

### DIFF
--- a/altsrc.go
+++ b/altsrc.go
@@ -42,12 +42,19 @@ func tracef(format string, a ...any) {
 	)
 }
 
-// NestedVal checks if the name has '.' delimiters.
-// If so, it tries to traverse the tree by the '.' delimited sections to find
+// NestedVal returns a value from the given map. The lookup name may be a dot-separated path into the map.
+// If that is the case, it will recursively traverse the map based on the '.' delimited sections to find
 // a nested value for the key.
 func NestedVal(name string, tree map[any]any) (any, bool) {
-	if sections := strings.Split(name, "."); len(sections) > 1 {
-		node := tree
+	sections := strings.Split(name, ".")
+	if name == "" || len(sections) == 0 {
+		return nil, false
+	}
+
+	node := tree
+
+	// traverse into the map based on the dot-separated sections
+	if len(sections) >= 2 { // the last section is the value we want, we will return it directly at the end
 		for _, section := range sections[:len(sections)-1] {
 			child, ok := node[section]
 			if !ok {
@@ -66,10 +73,10 @@ func NestedVal(name string, tree map[any]any) (any, bool) {
 				return nil, false
 			}
 		}
-		if val, ok := node[sections[len(sections)-1]]; ok {
-			return val, true
-		}
 	}
 
+	if val, ok := node[sections[len(sections)-1]]; ok {
+		return val, true
+	}
 	return nil, false
 }

--- a/altsrc_test.go
+++ b/altsrc_test.go
@@ -19,11 +19,11 @@ var (
 
 func TestNestedVal(t *testing.T) {
 	tests := []struct {
-		name string
-		key  string
-		m    map[any]any
-		val  any
-		b    bool
+		name  string
+		key   string
+		m     map[any]any
+		val   any
+		found bool
 	}{
 		{
 			name: "No map no key",
@@ -49,6 +49,15 @@ func TestNestedVal(t *testing.T) {
 			},
 		},
 		{
+			name: "Level 1",
+			key:  "foobar",
+			m: map[any]any{
+				"foobar": 10,
+			},
+			val:   10,
+			found: true,
+		},
+		{
 			name: "Level 2",
 			key:  "foo.bar",
 			m: map[any]any{
@@ -56,8 +65,8 @@ func TestNestedVal(t *testing.T) {
 					"bar": 10,
 				},
 			},
-			val: 10,
-			b:   true,
+			val:   10,
+			found: true,
 		},
 		{
 			name: "Level 2 invalid key",
@@ -65,6 +74,15 @@ func TestNestedVal(t *testing.T) {
 			m: map[any]any{
 				"foo": map[any]any{
 					"bar": 10,
+				},
+			},
+		},
+		{
+			name: "Level 2 string map type",
+			key:  "foo.bar1",
+			m: map[any]any{
+				"foo": map[string]any{
+					"bar": "10",
 				},
 			},
 		},
@@ -87,8 +105,8 @@ func TestNestedVal(t *testing.T) {
 					},
 				},
 			},
-			val: "sss",
-			b:   true,
+			val:   "sss",
+			found: true,
 		},
 		{
 			name: "Level 3 invalid key",
@@ -124,15 +142,15 @@ func TestNestedVal(t *testing.T) {
 					},
 				},
 			},
-			val: []int{10},
-			b:   true,
+			val:   []int{10},
+			found: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			val, b := NestedVal(test.key, test.m)
-			if !test.b {
+			if !test.found {
 				assert.False(t, b)
 			} else {
 				assert.True(t, b)

--- a/uri_source_cache_test.go
+++ b/uri_source_cache_test.go
@@ -36,7 +36,12 @@ func TestReadURI(t *testing.T) {
 		{
 			name: "Invalid http URL",
 			path: "http://foo",
-			err:  "no such host",
+
+			// locally we get: "dial tcp: lookup foo: no such host"
+			// but on CI local networks are disabled,
+			// so the error is: "dial tcp: lookup foo on 127.0.0.11:53: server misbehaving"
+			// therefore let's check for the "lookup foo", which is in both errors
+			err: "lookup foo",
 		},
 		{
 			name: "valid http URL",


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

It fixes a bug in `NestedVal` where lookup doesn't work for keys directly in the first level (root) of the map.

## Which issue(s) this PR fixes:

Fixes #14  

## Special notes for your reviewer:

The issue is related to this one I raised in `cli`: https://github.com/urfave/cli/issues/2037
I created a related PR there as well: https://github.com/urfave/cli/pull/2047

The source code of `NestedVal`, and even the tests seem to be a copy paste from `urfave/cli` in this case.
I kept it now like this as well - though there would be a possibility to remove that duplication by moving the `NestedVal` function to `urfave/cli` directly, make it public and use it there inside `MapSource.Lookup` and then also in `cli-altsrc`.

If you prefer that approach I could update my PRs accordingly - though this would require the `urfave/cli` one to be merged and released before this PR can be updated to rely on it.

## Testing

I added a test case for this exact issue as well. It will fail without changes from the PR.
I also added another test case for the `map[string]any` special case that was in place in the code, to make sure that works to.

