### PR TITLE
Fix: Decouple cli interface from altsrc

### DIFF
--- a/altsrc.go
+++ b/altsrc.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-
-	"github.com/urfave/cli/v3"
 )
 
 var (
@@ -107,14 +105,14 @@ func (s StringPtrSourcer) SourceURI() string {
 	return *s.ptr
 }
 
-type valueSource struct {
+type ValueSource struct {
 	key     string
 	desc    string
 	sourcer Sourcer
 	um      func([]byte, any) error
 }
 
-func (vs *valueSource) Lookup() (string, bool) {
+func (vs *ValueSource) Lookup() (string, bool) {
 	maafsc := NewMapAnyAnyURISourceCache(vs.sourcer.SourceURI(), vs.um)
 	if v, ok := NestedVal(vs.key, maafsc.Get()); ok {
 		return fmt.Sprintf("%[1]v", v), ok
@@ -123,31 +121,19 @@ func (vs *valueSource) Lookup() (string, bool) {
 	return "", false
 }
 
-func (vs *valueSource) String() string {
+func (vs *ValueSource) String() string {
 	return fmt.Sprintf("%s file %[2]q at key %[3]q", vs.desc, vs.sourcer.SourceURI(), vs.key)
 }
 
-func (vs *valueSource) GoString() string {
+func (vs *ValueSource) GoString() string {
 	return fmt.Sprintf("%sValueSource{file:%[2]q,keyPath:%[3]q}", vs.desc, vs.sourcer.SourceURI(), vs.key)
 }
 
-func NewValueSource(f func([]byte, any) error, desc string, key string, uriSrc Sourcer) cli.ValueSource {
-	return &valueSource{
+func NewValueSource(f func([]byte, any) error, desc string, key string, uriSrc Sourcer) *ValueSource {
+	return &ValueSource{
 		sourcer: uriSrc,
 		key:     key,
 		desc:    desc,
 		um:      f,
-	}
-}
-
-func NewValueSourceChain(f func([]byte, any) error, desc string, key string, uris ...Sourcer) cli.ValueSourceChain {
-	vs := []cli.ValueSource{}
-
-	for _, uri := range uris {
-		vs = append(vs, NewValueSource(f, desc, key, uri))
-	}
-
-	return cli.ValueSourceChain{
-		Chain: vs,
 	}
 }

--- a/json/json_value_source.go
+++ b/json/json_value_source.go
@@ -2,12 +2,11 @@ package json
 
 import (
 	altsrc "github.com/urfave/cli-altsrc/v3"
-	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
 )
 
 // JSON is a helper function that wraps the YAML helper function
 // and loads via yaml.Unmarshal
-func JSON(key string, source altsrc.Sourcer) cli.ValueSource {
+func JSON(key string, source altsrc.Sourcer) *altsrc.ValueSource {
 	return altsrc.NewValueSource(yaml.Unmarshal, "json", key, source)
 }

--- a/toml/toml_value_source.go
+++ b/toml/toml_value_source.go
@@ -3,11 +3,10 @@ package toml
 import (
 	"github.com/BurntSushi/toml"
 	altsrc "github.com/urfave/cli-altsrc/v3"
-	"github.com/urfave/cli/v3"
 )
 
 // TOML is a helper function to encapsulate a number of
 // tomlValueSource together as a cli.ValueSourceChain
-func TOML(key string, source altsrc.Sourcer) cli.ValueSource {
+func TOML(key string, source altsrc.Sourcer) *altsrc.ValueSource {
 	return altsrc.NewValueSource(toml.Unmarshal, "toml", key, source)
 }

--- a/yaml/yaml_value_source.go
+++ b/yaml/yaml_value_source.go
@@ -2,12 +2,11 @@ package yaml
 
 import (
 	altsrc "github.com/urfave/cli-altsrc/v3"
-	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
 )
 
 // YAML is a helper function to encapsulate a number of
 // yamlValueSource together as a cli.ValueSourceChain
-func YAML(key string, source altsrc.Sourcer) cli.ValueSource {
+func YAML(key string, source altsrc.Sourcer) *altsrc.ValueSource {
 	return altsrc.NewValueSource(yaml.Unmarshal, "yaml", key, source)
 }


### PR DESCRIPTION
Remove the direct dependency of using cli.ValueSource from altsrc. The tests still verify that the instances returned by altsrc satisfy cli interfaces