### PR TITLE
bug: Fix support for slice types across all formats

### DIFF
--- a/.testdata/slice.json
+++ b/.testdata/slice.json
@@ -1,0 +1,13 @@
+{
+  "slice_types": {
+    "numbers": [
+      1,
+      2,
+      3
+    ],
+    "strings": [
+      "word",
+      "this is a sentence"
+    ]
+  }
+}

--- a/.testdata/slice.toml
+++ b/.testdata/slice.toml
@@ -1,0 +1,10 @@
+[slice_types]
+numbers = [
+  1,
+  2,
+  3,
+]
+strings = [
+  "word",
+  "this is a sentence",
+]

--- a/.testdata/slice.yaml
+++ b/.testdata/slice.yaml
@@ -1,0 +1,8 @@
+slice_types:
+  numbers:
+    - 1
+    - 2
+    - 3
+  strings:
+    - "word"
+    - "this is a sentence"

--- a/altsrc.go
+++ b/altsrc.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 )
@@ -115,6 +116,23 @@ type ValueSource struct {
 func (vs *ValueSource) Lookup() (string, bool) {
 	maafsc := NewMapAnyAnyURISourceCache(vs.sourcer.SourceURI(), vs.um)
 	if v, ok := NestedVal(vs.key, maafsc.Get()); ok {
+		// Use reflection to check if 'v' is a slice
+		if val := reflect.ValueOf(v); val.Kind() == reflect.Slice {
+			// It's a slice, so create a new string slice of the same size
+			stringSlice := make([]string, val.Len())
+
+			// Iterate over the slice elements
+			for i := 0; i < val.Len(); i++ {
+				// Get the element at index i and convert it to a string
+				elem := val.Index(i).Interface()
+				stringSlice[i] = fmt.Sprintf("%v", elem)
+			}
+
+			// Join the string representations and return
+			return strings.Join(stringSlice, ","), true
+		}
+
+		// Fall back to standard string representation if not a slice
 		return fmt.Sprintf("%[1]v", v), ok
 	}
 

--- a/json/json_value_source_test.go
+++ b/json/json_value_source_test.go
@@ -50,3 +50,35 @@ func TestJSON(t *testing.T) {
 	r.Equal("yaml file \"/dev/null/nonexistent.json\" at key \"water_fountain.water\"", yvs.String())
 	r.Equal("yamlValueSource{file:\"/dev/null/nonexistent.json\",keyPath:\"water_fountain.water\"}", yvs.GoString())
 }
+
+func TestJSONSlice(t *testing.T) {
+	r := require.New(t)
+
+	configPath := filepath.Join(testdataDir, "slice.json")
+
+	t.Run("numbers", func(t *testing.T) {
+		vs := JSON(
+			"slice_types.numbers",
+			altsrc.StringSourcer(configPath),
+		)
+
+		vsc := cli.NewValueSourceChain(vs)
+
+		v, ok := vsc.Lookup()
+		r.Equal("1,2,3", v)
+		r.True(ok)
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		vs := JSON(
+			"slice_types.strings",
+			altsrc.StringSourcer(configPath),
+		)
+
+		vsc := cli.NewValueSourceChain(vs)
+
+		v, ok := vsc.Lookup()
+		r.Equal("word,this is a sentence", v)
+		r.True(ok)
+	})
+}

--- a/toml/toml_value_source_test.go
+++ b/toml/toml_value_source_test.go
@@ -50,3 +50,35 @@ func TestTOML(t *testing.T) {
 	r.Equal("toml file \"/dev/null/nonexistent.toml\" at key \"water_fountain.water\"", tvs.String())
 	r.Equal("tomlValueSource{file:\"/dev/null/nonexistent.toml\",keyPath:\"water_fountain.water\"}", tvs.GoString())
 }
+
+func TestTOMLSlice(t *testing.T) {
+	r := require.New(t)
+
+	configPath := filepath.Join(testdataDir, "slice.toml")
+
+	t.Run("numbers", func(t *testing.T) {
+		vs := TOML(
+			"slice_types.numbers",
+			altsrc.StringSourcer(configPath),
+		)
+
+		vsc := cli.NewValueSourceChain(vs)
+
+		v, ok := vsc.Lookup()
+		r.Equal("1,2,3", v)
+		r.True(ok)
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		vs := TOML(
+			"slice_types.strings",
+			altsrc.StringSourcer(configPath),
+		)
+
+		vsc := cli.NewValueSourceChain(vs)
+
+		v, ok := vsc.Lookup()
+		r.Equal("word,this is a sentence", v)
+		r.True(ok)
+	})
+}

--- a/yaml/yaml_value_source_test.go
+++ b/yaml/yaml_value_source_test.go
@@ -49,3 +49,35 @@ func TestYAML(t *testing.T) {
 	r.Equal("yaml file \"/dev/null/nonexistent.yaml\" at key \"water_fountain.water\"", yvs.String())
 	r.Equal("yamlValueSource{file:\"/dev/null/nonexistent.yaml\",keyPath:\"water_fountain.water\"}", yvs.GoString())
 }
+
+func TestYAMLSlice(t *testing.T) {
+	r := require.New(t)
+
+	configPath := filepath.Join(testdataDir, "slice.yaml")
+
+	t.Run("numbers", func(t *testing.T) {
+		vs := YAML(
+			"slice_types.numbers",
+			altsrc.StringSourcer(configPath),
+		)
+
+		vsc := cli.NewValueSourceChain(vs)
+
+		v, ok := vsc.Lookup()
+		r.Equal("1,2,3", v)
+		r.True(ok)
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		vs := YAML(
+			"slice_types.strings",
+			altsrc.StringSourcer(configPath),
+		)
+
+		vsc := cli.NewValueSourceChain(vs)
+
+		v, ok := vsc.Lookup()
+		r.Equal("word,this is a sentence", v)
+		r.True(ok)
+	})
+}


### PR DESCRIPTION
Use reflection to re-encode slices in a way that upstream urfave/cli expects.

fixes #24 