### PR TITLE
feat: support string map values from config sources

### DIFF
--- a/.testdata/map.json
+++ b/.testdata/map.json
@@ -1,0 +1,8 @@
+{
+  "map_types": {
+    "labels": {
+      "env": "prod",
+      "team": "platform"
+    }
+  }
+}

--- a/.testdata/map.toml
+++ b/.testdata/map.toml
@@ -1,0 +1,3 @@
+[map_types.labels]
+env = "prod"
+team = "platform"

--- a/.testdata/map.yaml
+++ b/.testdata/map.yaml
@@ -1,0 +1,4 @@
+map_types:
+  labels:
+    env: prod
+    team: platform

--- a/altsrc.go
+++ b/altsrc.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+
+	"github.com/urfave/cli/v3"
 )
 
 var (
@@ -116,27 +118,36 @@ type ValueSource struct {
 func (vs *ValueSource) Lookup() (string, bool) {
 	maafsc := NewMapAnyAnyURISourceCache(vs.sourcer.SourceURI(), vs.um)
 	if v, ok := NestedVal(vs.key, maafsc.Get()); ok {
-		// Use reflection to check if 'v' is a slice
-		if val := reflect.ValueOf(v); val.Kind() == reflect.Slice {
-			// It's a slice, so create a new string slice of the same size
-			stringSlice := make([]string, val.Len())
-
-			// Iterate over the slice elements
-			for i := 0; i < val.Len(); i++ {
-				// Get the element at index i and convert it to a string
-				elem := val.Index(i).Interface()
-				stringSlice[i] = fmt.Sprintf("%v", elem)
-			}
-
-			// Join the string representations and return
-			return strings.Join(stringSlice, ","), true
-		}
-
-		// Fall back to standard string representation if not a slice
-		return fmt.Sprintf("%[1]v", v), ok
+		return lookupString(v), true
 	}
 
 	return "", false
+}
+
+func lookupString(v any) string {
+	val := reflect.ValueOf(v)
+	if !val.IsValid() {
+		return ""
+	}
+
+	if val.Kind() == reflect.Slice {
+		stringSlice := make([]string, val.Len())
+		for i := 0; i < val.Len(); i++ {
+			stringSlice[i] = fmt.Sprintf("%v", val.Index(i).Interface())
+		}
+		return strings.Join(stringSlice, ",")
+	}
+
+	if val.Kind() == reflect.Map {
+		stringMap := make(map[string]string, val.Len())
+		iter := val.MapRange()
+		for iter.Next() {
+			stringMap[fmt.Sprintf("%v", iter.Key().Interface())] = fmt.Sprintf("%v", iter.Value().Interface())
+		}
+		return cli.NewStringMap(stringMap).Serialize()
+	}
+
+	return fmt.Sprintf("%[1]v", v)
 }
 
 func (vs *ValueSource) String() string {

--- a/json/json_value_source_test.go
+++ b/json/json_value_source_test.go
@@ -51,6 +51,23 @@ func TestJSON(t *testing.T) {
 	r.Equal("yamlValueSource{file:\"/dev/null/nonexistent.json\",keyPath:\"water_fountain.water\"}", yvs.GoString())
 }
 
+func TestJSONStringMap(t *testing.T) {
+	r := require.New(t)
+
+	configPath := filepath.Join(testdataDir, "map.json")
+	vs := JSON(
+		"map_types.labels",
+		altsrc.StringSourcer(configPath),
+	)
+
+	v, ok := cli.NewValueSourceChain(vs).Lookup()
+	r.True(ok)
+
+	m := cli.NewStringMap(nil)
+	r.NoError(m.Set(v))
+	r.Equal(map[string]string{"env": "prod", "team": "platform"}, m.Value())
+}
+
 func TestJSONSlice(t *testing.T) {
 	r := require.New(t)
 

--- a/toml/toml_value_source_test.go
+++ b/toml/toml_value_source_test.go
@@ -51,6 +51,23 @@ func TestTOML(t *testing.T) {
 	r.Equal("tomlValueSource{file:\"/dev/null/nonexistent.toml\",keyPath:\"water_fountain.water\"}", tvs.GoString())
 }
 
+func TestTOMLStringMap(t *testing.T) {
+	r := require.New(t)
+
+	configPath := filepath.Join(testdataDir, "map.toml")
+	vs := TOML(
+		"map_types.labels",
+		altsrc.StringSourcer(configPath),
+	)
+
+	v, ok := cli.NewValueSourceChain(vs).Lookup()
+	r.True(ok)
+
+	m := cli.NewStringMap(nil)
+	r.NoError(m.Set(v))
+	r.Equal(map[string]string{"env": "prod", "team": "platform"}, m.Value())
+}
+
 func TestTOMLSlice(t *testing.T) {
 	r := require.New(t)
 

--- a/yaml/yaml_value_source_test.go
+++ b/yaml/yaml_value_source_test.go
@@ -50,6 +50,23 @@ func TestYAML(t *testing.T) {
 	r.Equal("yamlValueSource{file:\"/dev/null/nonexistent.yaml\",keyPath:\"water_fountain.water\"}", yvs.GoString())
 }
 
+func TestYAMLStringMap(t *testing.T) {
+	r := require.New(t)
+
+	configPath := filepath.Join(testdataDir, "map.yaml")
+	vs := YAML(
+		"map_types.labels",
+		altsrc.StringSourcer(configPath),
+	)
+
+	v, ok := cli.NewValueSourceChain(vs).Lookup()
+	r.True(ok)
+
+	m := cli.NewStringMap(nil)
+	r.NoError(m.Set(v))
+	r.Equal(map[string]string{"env": "prod", "team": "platform"}, m.Value())
+}
+
 func TestYAMLSlice(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
## Summary
- serialize map values with `cli.NewStringMap(...).Serialize()` in `ValueSource.Lookup`
- preserve existing slice/scalar behavior
- add JSON/YAML/TOML coverage for `StringMapFlag`-compatible values

## Why
`cli-altsrc` could already source scalar and slice values from config files, but object/map values were stringified with `fmt.Sprintf`, which is not compatible with `urfave/cli/v3` `StringMapFlag` parsing. This change makes config-backed map values round-trip through the same serialized format used by `cli.NewStringMap`.

## Notes
- no behavior change for scalar or slice lookups
- added format coverage for JSON, YAML, and TOML
